### PR TITLE
Only do the scroll fix on older versions of BuddyPress

### DIFF
--- a/includes/js/bp-activity-privacy.js
+++ b/includes/js/bp-activity-privacy.js
@@ -188,12 +188,19 @@ jq(document).ready( function() {
 				jq("textarea#whats-new").val('');
 			}
 
-			jq("#whats-new-options").animate({
-				height:'0px'
-			});
-			jq("form#whats-new-form textarea").animate({
-				height:'20px'
-			});
+			if ( 'border-box' !== jq( '#whats-new' ).css( 'box-sizing' ) ) {
+				jq("#whats-new-options").animate({
+					height:'0px'
+				});
+				jq("form#whats-new-form textarea").animate({
+					height:'20px'
+				});
+			} else {
+				jq( '#whats-new' ).animate({
+					height: '2.2em'
+				})
+				jq( '#whats-new-options' ).slideUp();
+			}
 			jq("#aw-whats-new-submit").prop("disabled", true).removeClass('loading');
 
 			//reset the privacy selection

--- a/includes/js/bp-activity-privacy.js
+++ b/includes/js/bp-activity-privacy.js
@@ -64,6 +64,7 @@ jq(document).ready( function() {
 	if ( 'border-box' !== jq( '#whats-new' ).css( 'box-sizing' ) ) {
 		jq('#whats-new').off('focus');
 		jq('#whats-new').on('focus', function(){
+			jq("#whats-new-options").css('height','auto');
 			jq("form#whats-new-form textarea").animate({
 				height:'50px'
 			});

--- a/includes/js/bp-activity-privacy.js
+++ b/includes/js/bp-activity-privacy.js
@@ -61,14 +61,15 @@ jq(document).ready( function() {
 	});
 
 	//fix the scroll problem
-    jq('#whats-new').off('focus');
-    jq('#whats-new').on('focus', function(){
-        jq("#whats-new-options").css('height','auto');
-        jq("form#whats-new-form textarea").animate({
-            height:'50px'
-        });
-        jq("#aw-whats-new-submit").prop("disabled", false);
-    });
+	if ( 'border-box' !== jq( '#whats-new' ).css( 'box-sizing' ) ) {
+		jq('#whats-new').off('focus');
+		jq('#whats-new').on('focus', function(){
+			jq("form#whats-new-form textarea").animate({
+				height:'50px'
+			});
+			jq("#aw-whats-new-submit").prop("disabled", false);
+		});
+	}
 
 	jq('span#activity-visibility').prependTo('div#whats-new-submit');
 	jq("input#aw-whats-new-submit").off("click");


### PR DESCRIPTION
Hi Messaoudi,

Buddypress 2.4.0 has better styles for the "What's New" activity form now and doesn't require the scroll fix.

I've created a pull request to only add the scroll fix on older versions of BuddyPress.

Let me know if you have any questions!
